### PR TITLE
Add support for VirtualFish

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@ Based on the robbyrussell theme.
 * Displays git information in the command prompt when available.
 * Indicates 'master' branch with a distinctive color, encouraging the use of feature-branches (useful when development is done using pull requests)
 * If the last command was failed, the indicator would be red, otherwise it's green
+* If active, displays the Python virtualenv in the prompt (compatible with [VirtualFish](https://virtualfish.readthedocs.io/))

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -44,5 +44,9 @@ function fish_prompt
     echo The last command took (math "$CMD_DURATION/1000") seconds.
   end
 
-  echo -n -s $status_indicator $cwd $git_info $normal ' '
+  if set -q VIRTUAL_ENV
+    set virtualfish_info $normal "(" (basename $VIRTUAL_ENV) ") "
+  end
+
+  echo -n -s $status_indicator $virtualfish_info $cwd $git_info $normal ' '
 end


### PR DESCRIPTION
Hi, first of all, thanks for this awesome, simple, beautiful, and straightforward theme : ) I have been using it for more than a year and I just love it.

As a Python developer, I miss seeing if I have a virtual environment active or not. In Fish, may people use [VirtualFish](https://virtualfish.readthedocs.io), so I added a few lines to this theme to allow it to show the virtual environment (when active) in the prompt.

Is this of interest to the main repository of the theme?